### PR TITLE
fix dependency to puppet/augeasproviders_core

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "description": "This module provides types/providers for nagios using the Augeas configuration API library.",
   "dependencies": [
     {
-      "name": "herculesteam/augeasproviders_core",
+      "name": "puppet/augeasproviders_core",
       "version_requirement": ">=2.4.0 <3.0.0"
     }
   ],


### PR DESCRIPTION
The herculesteam migrated their augeasprovider modules to voxpupuli, we should reflect this change in the dependencies.