### PR TITLE
Fix voxpupuli github links in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,9 +4,9 @@
   "author": "Vox Pupuli",
   "summary": "Augeas-based nagios types and providers for Puppet",
   "license": "Apache-2.0",
-  "source": "https://github.com/puppet/augeasproviders_nagios",
-  "project_page": "https://github.com/puppet/augeasproviders_nagios",
-  "issues_url": "https://github.com/puppet/augeasproviders_nagios/issues",
+  "source": "https://github.com/voxpupuli/augeasproviders_nagios",
+  "project_page": "https://github.com/voxpupuli/augeasproviders_nagios",
+  "issues_url": "https://github.com/voxpupuli/augeasproviders_nagios/issues",
   "description": "This module provides types/providers for nagios using the Augeas configuration API library.",
   "dependencies": [
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Updates `https://github.com/puppet/` to `https://github.com/voxpupuli/` since that crosslink doesn't seem to work anymore.